### PR TITLE
Use Moo + Type::Tiny for object management

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,8 +9,9 @@ WriteMakefile
   'EXE_FILES' => [],
   'VERSION_FROM' => 'lib/Games/Maze.pm',
   'PREREQ_PM' => {
-                   'parent' => 0,
-                   'Test::Simple' => 0
+                   'Test::Simple' => 0,
+                   'Type::Tiny' => 0,
+                   'Moo' => 0,
                  }
 )
 ;


### PR DESCRIPTION
This is a minimal attempt at addressing #2, since it seems previous efforts stalled.

The changes in this commit replace the hand-crafted object management with Moo for the OO code and Type::Tiny for the validation of attributes. I made the effort to touch as little as possible of the existing code, so the existing API should remain the same, and there were no changes needed to the test suite.
